### PR TITLE
Correction detection Type Rom

### DIFF
--- a/projectSrc/src/gb/core/Rom.cpp
+++ b/projectSrc/src/gb/core/Rom.cpp
@@ -35,9 +35,9 @@ void		Rom::init(void)
 	uint8_t	flag_cgb;
 
 	flag_cgb = (this->_rom[CGBFLAG] & 0xFF);
-	if (flag_cgb == 0x00 || flag_cgb == 0x80)
+	if (flag_cgb == 0x00)
 		this->_hardware = GB;
-	else if (flag_cgb == 0xC0)
+	else if (flag_cgb == 0xC0 || flag_cgb == 0x80)
 		this->_hardware = GBC;
 	if (this->getBankEram(this->_rom[RAMSIZE]) > 0)
 		this->_eram = new uint8_t [this->getBankEram(this->_rom[RAMSIZE]) * 8192];


### PR DESCRIPTION
 -> 0x00 = GB
 -> 0x80 = GBC
 -> 0xC0 = GBC ONLY // si type forcer a GB Rom affiche erreur